### PR TITLE
Correção da pesquisa por data

### DIFF
--- a/src/main/java/br/com/banco/controller/TransferenciaController.java
+++ b/src/main/java/br/com/banco/controller/TransferenciaController.java
@@ -27,11 +27,11 @@ public class TransferenciaController {
 
     @GetMapping
     @ResponseBody
-    public ResponseEntity<List<Transferencia>> getTransferencias(@RequestParam Long idConta,
-        @RequestParam Optional<String> dataTransferencia, @RequestParam Optional<String> nome) {
+    public ResponseEntity<List<Transferencia>> getTransferencias(@RequestParam Long idConta,@RequestParam Optional<String> dataInicio,
+        @RequestParam Optional<String> dataFim, @RequestParam Optional<String> nome) {
             
         List<Transferencia> transferencias = this.transferenciaService
-                                            .getTransferenciasPaginadas(idConta, dataTransferencia, nome);
+                                            .getTransferenciasPaginadas(idConta, dataInicio, dataFim, nome);
 
         return new ResponseEntity<List<Transferencia>>(transferencias, HttpStatus.OK);
     }

--- a/src/main/java/br/com/banco/model/Transferencia.java
+++ b/src/main/java/br/com/banco/model/Transferencia.java
@@ -1,10 +1,7 @@
 package br.com.banco.model;
 
 import java.math.BigDecimal;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
+import java.time.OffsetDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -28,8 +25,7 @@ public class Transferencia {
     private Long idTransferencia;
 
     @Column(name = "data_transferencia")
-    private ZonedDateTime dataTransferencia = ZonedDateTime.ofInstant(Instant.now()
-        , ZoneId.of("America/Sao_Paulo"));
+    private OffsetDateTime dataTransferencia;
     
     @Column(precision = 20, scale = 2, nullable = false)
     private BigDecimal valor;

--- a/src/main/java/br/com/banco/repository/TransferenciaRepository.java
+++ b/src/main/java/br/com/banco/repository/TransferenciaRepository.java
@@ -1,6 +1,6 @@
 package br.com.banco.repository;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -14,12 +14,12 @@ import br.com.banco.model.Transferencia;
 public interface TransferenciaRepository extends JpaRepository<Transferencia, Long>{
     
     @Query("select t from Transferencia t join fetch t.conta c where c.idConta = :idConta and t.nomeOperador = :nome" +
-    " and t.dataTransferencia like concat(:date,'%')")
-    List<Transferencia> findByIdContaDataNome(Long idConta, LocalDate date, String nome, Pageable paginacao);
+    " and t.dataTransferencia between :date1 and :date2")
+    List<Transferencia> findByIdContaDataNome(Long idConta, OffsetDateTime date1, OffsetDateTime date2, String nome, Pageable paginacao);
     
     @Query("select t from Transferencia t join fetch t.conta c where c.idConta = :idConta" + 
-    " and t.dataTransferencia like concat(:date,'%')")
-    List<Transferencia> findByIdContaData(Long idConta, LocalDate date, Pageable paginacao);
+    " and t.dataTransferencia between :date1 and :date2")
+    List<Transferencia> findByIdContaData(Long idConta, OffsetDateTime date1, OffsetDateTime date2, Pageable paginacao);
 
     @Query("select t from Transferencia t join fetch t.conta c where c.idConta = :idConta and t.nomeOperador = :nome")
     List<Transferencia> findByIdContaNome(Long idConta, String nome, Pageable paginacao);

--- a/src/main/java/br/com/banco/service/TransferenciaService.java
+++ b/src/main/java/br/com/banco/service/TransferenciaService.java
@@ -1,6 +1,6 @@
 package br.com.banco.service;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
@@ -17,16 +17,20 @@ import br.com.banco.repository.TransferenciaRepository;
 public class TransferenciaService {
     @Autowired
     TransferenciaRepository transferenciaRepository;
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
     public List<Transferencia> getTransferenciasPaginadas(Long idConta, 
-        Optional<String> dataTransferencia, Optional<String> nome) {
+        Optional<String> dataInicio, Optional<String> dataFim, Optional<String> nome) {
 
-            LocalDate date = null;
-            if(dataTransferencia.isPresent()){
-                String data = dataTransferencia.get();
-                date = LocalDate.parse(data, formatter);
-                
+            boolean datasPresentes = false;
+            OffsetDateTime dataInicial = null;
+            OffsetDateTime dataFinal = null;
+            if(dataInicio.isPresent() && dataFim.isPresent()){
+                String data1 = dataInicio.get() + "T00:00:00+03:00";
+                String data2 = dataFim.get() + "T23:59:59+03:00";
+                dataInicial = OffsetDateTime.parse(data1, formatter);
+                dataFinal = OffsetDateTime.parse(data2, formatter);
+                datasPresentes = true;
             }
 
             String nomeOperador = null;
@@ -38,13 +42,13 @@ public class TransferenciaService {
             PageRequest paginacao = PageRequest.of(0, 5, sort);
 
             List<Transferencia> transferencias = null;
-            if(dataTransferencia.isPresent() && nome.isPresent()) {
-                transferencias = this.transferenciaRepository.findByIdContaDataNome(idConta, date, nomeOperador, paginacao);
+            if(datasPresentes && nome.isPresent()) {
+                transferencias = this.transferenciaRepository.findByIdContaDataNome(idConta, dataInicial, dataFinal, nomeOperador, paginacao);
 
-            } else if (dataTransferencia.isPresent() && nome.isEmpty()){
-                transferencias = this.transferenciaRepository.findByIdContaData(idConta, date, paginacao);
+            } else if (datasPresentes && nome.isEmpty()){
+                transferencias = this.transferenciaRepository.findByIdContaData(idConta, dataInicial, dataFinal, paginacao);
 
-            } else if (dataTransferencia.isEmpty() && nome.isPresent()){
+            } else if (!datasPresentes && nome.isPresent()){
                 transferencias = this.transferenciaRepository.findByIdContaNome(idConta, nomeOperador, paginacao);
                 
             } else {


### PR DESCRIPTION
- A pesquisa por data agora recebe uma data de início e uma de fim, buscando registros dentro do período, em oposto a receber uma data só e buscar por ela como estava antes